### PR TITLE
Added missing dependencies in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,15 +1,22 @@
 julia 1.0
+AbstractFFTs
+Conda
 InplaceOps
+DifferentialEquations
+Distances
+Distributions
+Documenter
+DocumenterMarkdown
 DynamicalSystemsBase
 DynamicalSystems
-Distributions
-Distances
+NearestNeighbors
+Interpolations
+PerronFrobenius 0.2.0
+Plots
+PyCall
 RecipesBase
 Reexport
-Plots
-DifferentialEquations
-TimeseriesSurrogates 0.2.1
 Simplices 0.2.1
 StateSpaceReconstruction 0.3.0
-PerronFrobenius 0.2.0
+TimeseriesSurrogates 0.2.1
 TransferEntropy 0.3.1


### PR DESCRIPTION
All packages that are in Project.toml and not included in the standard library must be in REQUIRE. 

This is not done automatically and JuliaCIBot does not seem to detect it, so sure to check that REQUIRE and Project.toml contain the same packages for each release. 